### PR TITLE
Update package.json to use newer SFDC npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@oclif/command": "1",
         "@oclif/config": "1",
         "@oclif/errors": "1",
-        "@salesforce/command": "^1.0.1",
-        "@salesforce/core": "^1.0.1"
+        "@salesforce/command": "^2.1.0",
+        "@salesforce/core": "^2.1.0"
     }
 }


### PR DESCRIPTION
@ChuckJonas - Update reference to @salesforce dependencies to use more current npm packages to address the "unknown cipher" error that started with VS Code 1.36 update. (See Issue #8)